### PR TITLE
Add closing div tags in admin and appointment components

### DIFF
--- a/frontend-hospitalms/src/app/admindash/admindash.component.html
+++ b/frontend-hospitalms/src/app/admindash/admindash.component.html
@@ -72,3 +72,5 @@
         }
       </tbody>
     </table>
+  </div>
+  

--- a/frontend-hospitalms/src/app/appointment/appointment.component.html
+++ b/frontend-hospitalms/src/app/appointment/appointment.component.html
@@ -79,3 +79,4 @@
         }
       </tbody>
     </table>
+  </div>


### PR DESCRIPTION
Added missing closing </div> tags in admindash.component.html and appointment.component.html to ensure proper HTML structure and layout.